### PR TITLE
Fix user/guest/system time reporting

### DIFF
--- a/pcp-pidstat.py
+++ b/pcp-pidstat.py
@@ -94,13 +94,18 @@ class PidstatReport(pmcc.MetricGroupPrinter):
         percsystime = {}
         perccpuusage = {}
 
+        # FIXME: this should be the time interval between fetches, we can't assume its 1 second.
+        # Look at how it is done in pcp-iostat (look at IostatReport.timeStampDelta method)
+        interval_in_seconds = 1
+
         for inst in inst_list:
-            percusertime[inst] = 100*(float(c_usertimes[inst] - p_usertimes[inst])/(c_totalusertimes - p_totalusertimes))
+            percusertime[inst] = 100*float(c_usertimes[inst] - p_usertimes[inst])/1000*interval_in_seconds
             if (c_totalguesttimes - p_totalguesttimes) != 0:
-                percguesttime[inst] = 100*(float(c_guesttimes[inst] - p_guesttimes[inst])/(c_totalguesttimes - p_totalguesttimes))
+                percguesttime[inst] = 100*float(c_guesttimes[inst] - p_guesttimes[inst])/1000*interval_in_seconds
             else:
                 percguesttime[inst] = 0.00
             percsystime[inst] = 100*(float((c_systimes[inst] - p_systimes[inst]))/(c_totalsystimes - p_totalsystimes))
+            percsystime[inst] = 100*float(c_systimes[inst] - p_systimes[inst])/1000*interval_in_seconds
 
             c_proctimes = c_usertimes[inst]+c_systimes[inst]
             p_proctimes = p_usertimes[inst]+p_systimes[inst]


### PR DESCRIPTION
Hi Sitaram,

I've updated the reporting of time spent in user, guest and system. Given the metric is already converted into milliseconds, this should be all you need.

What we're doing here is getting the current time in milliseconds, minus the previous time, and converting it to a number between 0..1 to represent the ratio of time spend in the time slice (EG: `float(c_usertimes[inst] - p_usertimes[inst])/1000*interval_in_seconds`)

Then we convert it to a percentage like you had before (`100*`)

I've added some extra work for you to do as outlined in the FIXME section.

Let me know if you have any questions!

Cheers
