### PR TITLE
Extract out UserCpuUsage class and add test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+check:
+	python test/user_cpu_usage_test.py

--- a/test/pcp_pidstat.py
+++ b/test/pcp_pidstat.py
@@ -1,0 +1,1 @@
+../pcp-pidstat.py

--- a/test/user_cpu_usage_test.py
+++ b/test/user_cpu_usage_test.py
@@ -1,0 +1,45 @@
+import unittest
+from mock import Mock
+from pcp_pidstat import UserCpuUsage
+
+
+class TestUserCpuUsage(unittest.TestCase):
+    def test_cpu_usage_for_an_instance(self):
+        utime_mock = Mock(
+            netValues=[(Mock(inst=123), 'inst', 113300)],
+            netPrevValues=[(Mock(inst=123), 'inst', 113200)]
+        )
+        group = {'proc.psinfo.utime': utime_mock}
+        user_cpu_usage = UserCpuUsage(group)
+
+        user_percent_used = user_cpu_usage.for_instance(123, 1.34)
+
+        self.assertEquals(user_percent_used, 13.4)
+
+    def test_cpu_usage_for_an_instance_when_no_previous_values_returns_zero(self):
+        utime_mock = Mock(
+            netValues=[(Mock(inst=123), 'inst', 113300)],
+            netPrevValues=None
+        )
+        group = {'proc.psinfo.utime': utime_mock}
+        user_cpu_usage = UserCpuUsage(group)
+
+        user_percent_used = user_cpu_usage.for_instance(123, 1.34)
+
+        self.assertEquals(user_percent_used, 0)
+
+    def test_cpu_usage_when_no_instance_found_returns_none(self):
+        utime_mock = Mock(
+            netValues=[(Mock(inst=456), 'inst', 113300)],
+            netPrevValues=[(Mock(inst=456), 'inst', 113200)]
+        )
+        group = {'proc.psinfo.utime': utime_mock}
+        user_cpu_usage = UserCpuUsage(group)
+
+        user_percent_used = user_cpu_usage.for_instance(123, 1.34)
+
+        self.assertIsNone(user_percent_used)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi Sitaram,

Heres an example of how we could start extracting out some of the logic in the `report` method into some other classes. I wanted to point a few things out here:
- I've had to create a symlink of `pcp-pidstat` to `test/pcp_pidstat` so we can import it an use the classes in the test `user_cpu_usage_test.py`. This is a bit weird but it can do for now.
- `UserCpuUsage` is just a starting point. I think this could evolve to extract out other CPU-related metrics. Maybe all CPU usage metrics move into that class or a set of other classes.
- `c_usertimes` and `c_usertimes` still exist in `report` (so there is some doubling up at the moment as we also fetch these values in `UserCpuUsage`. These usages in `report` will go away as we extract out more.

Cheers!
