### PR TITLE
Fix optional option -U

### DIFF
--- a/pcp-pidstat.1
+++ b/pcp-pidstat.1
@@ -2,7 +2,7 @@
 .SH NAME
 \f3 pcp-pidstat\f1 \- Report statistics for Linux tasks.
 .SH SYNOPSIS
-\f3pcp\f1 \f3pidstat\f1 [\f3\-s\f1 N] [\f3\-t\f1 DELTA] [\f3\-I \f1] [\f3\-a\f1 FILE]  [\f3\-G\f1 NAME] [\f3\-U\f1  [USERNAME]] [\f3\-p\f1 PID1,PID2..] [\f3\-R\f1/\f3\-r/\f3\-k\f1] [\f3\-V \f1] [\f3\-?\f1]
+\f3pcp\f1 \f3pidstat\f1 [\f3\-s\f1 N] [\f3\-t\f1 DELTA] [\f3\-I \f1] [\f3\-a\f1 FILE]  [\f3\-G\f1 NAME] [\f3\-U\f1[USERNAME]] [\f3\-p\f1 PID1,PID2..] [\f3\-R\f1/\f3\-r/\f3\-k\f1] [\f3\-V \f1] [\f3\-?\f1]
 .SH DESCRIPTION
 .B pcp-pidstat
 command is used for monitoring individual tasks currently being managed by the Linux kernel. Using various options it helps user to see useful information related with the processes. This information can include percentage CPU, memory and stack usages, scheduling and priority information.
@@ -125,7 +125,7 @@ Ouput Filter Options
 Display only processes whose command name includes the string \fINAME\fR.  This string can be a regular expression.
 
 .TP
-.BR \-U \ [USERNAME] ", " \fB\-\-user\-name =\fI[USERNAME]\fR
+.BR \-U\fI[USERNAME] ", " \fB\-\-user\-name =\fI[USERNAME]\fR
 Display  the real user name of the tasks being monitored instead of the UID.  If \fIusername\fR is specified, then only tasks belonging to the specified user are displayed.
 
 .TP

--- a/pcp-pidstat.py
+++ b/pcp-pidstat.py
@@ -319,7 +319,7 @@ class CpuUsageReporter:
         self.pidstat_options = pidstat_options
 
     def print_report(self, timestamp, ncpu):
-        if self.pidstat_options.filtered_process_user is not None:
+        if self.pidstat_options.show_process_user:
             self.printer ("Timestamp\tUName\tPID\tusr\tsystem\tguest\t%CPU\tCPU\tCommand")
         else:
             self.printer ("Timestamp\tUID\tPID\tusr\tsystem\tguest\t%CPU\tCPU\tCommand")
@@ -341,7 +341,7 @@ class CpuUsageReporter:
             if self.pidstat_options.per_processor_usage:
                 total_percent = float("%.2f"%(total_percent/ncpu))
 
-            if self.pidstat_options.filtered_process_user is not None:
+            if self.pidstat_options.show_process_user:
                 self.printer("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (timestamp,process.user_name(),process.pid(),user_percent,system_percent,guest_percent,total_percent,process.cpu_number(),process.process_name()))
             else:
                 self.printer("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (timestamp,process.user_id(),process.pid(),user_percent,system_percent,guest_percent,total_percent,process.cpu_number(),process.process_name()))
@@ -440,7 +440,7 @@ class PidstatOptions(pmapi.pmOptions):
                     sys.exit(1)
 
     def __init__(self):
-        pmapi.pmOptions.__init__(self,"a:s:t:G:IU:P:RrkV?")
+        pmapi.pmOptions.__init__(self,"a:s:t:G:IU::P:RrkV?")
         self.pmSetOptionCallback(self.extraOptions)
         self.pmSetLongOptionHeader("General options")
         self.pmSetLongOptionArchive()
@@ -448,7 +448,7 @@ class PidstatOptions(pmapi.pmOptions):
         self.pmSetLongOptionInterval()
         self.pmSetLongOption("process-name",1,"G","NAME","Select process names using regular expression.")
         self.pmSetLongOption("",0,"I","","In SMP environment, show CPU usage per processor.")
-        self.pmSetLongOption("user-name",1,"U","[username]","Show real user name of the tasks and optionally filter by user name.")
+        self.pmSetLongOption("user-name",2,"U","[USERNAME]","Show real user name of the tasks and optionally filter by user name.")
         self.pmSetLongOption("pid-list",1,"P","PID1,PID2..  ","Show stats for specified pids, Use SELF for current process and ALL for all processes.")
         self.pmSetLongOption("",0,"R","","Report realtime priority and scheduling policy information.")
         self.pmSetLongOption("",0,"r","","Report page faults and memory utilization.")

--- a/test/cpu_usage_reporter_test.py
+++ b/test/cpu_usage_reporter_test.py
@@ -6,7 +6,7 @@ class TestCpuUsageReporter(unittest.TestCase):
     def setUp(self):
         self.options = Mock(
                         per_processor_usage = False,
-                        filtered_process_user = None)
+                        show_process_user = None)
 
         process_1 = Mock(pid = Mock(return_value = 1),
                         process_name = Mock(return_value = "process_1"),
@@ -32,7 +32,7 @@ class TestCpuUsageReporter(unittest.TestCase):
         printer.assert_called_with("123\t1000\t1\t2.43\t1.24\t0.0\t3.67\t1\tprocess_1")
 
     def test_print_report_with_user_name(self):
-        self.options.filtered_process_user = 'pcp'
+        self.options.show_process_user = 'pcp'
         cpu_usage = Mock()
         process_filter = Mock()
         printer = Mock()


### PR DESCRIPTION
It seems that GNU getopt requires that the optional argument is
specified right after the option (eg: -Oarg). pidstat implements its own
option parsing so thats how it was getting away with -O arg.
